### PR TITLE
Resource group members: allow nesting groups

### DIFF
--- a/gsuite/resource_group_members.go
+++ b/gsuite/resource_group_members.go
@@ -285,10 +285,10 @@ func upsertMember(email, gid, role string, config *Config) error {
 			}
 
 			// When a user does not exist, the API returns a 400 "memberKey, required"
-      // Returning a friendly message
-      if gerr, ok := err.(*googleapi.Error); ok && (gerr.Errors[0].Reason == "required" && gerr.Code == 400) {
-        return fmt.Errorf("Error adding groupMember %s. Please make sure the user exists beforehand.", email)
-      }
+			// Returning a friendly message
+			if gerr, ok := err.(*googleapi.Error); ok && (gerr.Errors[0].Reason == "required" && gerr.Code == 400) {
+			  return fmt.Errorf("Error adding groupMember %s. Please make sure the user exists beforehand.", email)
+			}
 			return err
 		})
 		if err != nil {

--- a/gsuite/resource_group_members.go
+++ b/gsuite/resource_group_members.go
@@ -168,6 +168,11 @@ func reconcileMembers(d *schema.ResourceData, cfgMembers, apiMembers []map[strin
 				groupMember := &directory.Member{
 					Role: cfgRole,
 				}
+
+				if cfgRole != "MEMBER" {
+					return fmt.Errorf("Error updating groupMember (%s): nested groups should be role MEMBER", cfgMember["email"].(string))
+				}
+
 				var updatedGroupMember *directory.Member
 				var err error
 				err = retry(func() error {
@@ -245,6 +250,10 @@ func upsertMember(email, gid, role string, config *Config) error {
 	}
 
 	if isGroup == true {
+		if role != "MEMBER" {
+			return fmt.Errorf("Error creating groupMember (%s): nested groups should be role MEMBER", email)
+		}
+
 		var currentMember *directory.Member
 		var err error
 		err = retry(func() error {


### PR DESCRIPTION
Fixes https://github.com/DeviaVir/terraform-provider-gsuite/issues/6

This adjusts the members resource to first check if an email is a group, and then use different logic for adding groups, or reverts to the current logic.

FYI @psalaberria002