### PR TITLE
Make it possible to run as a service account

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ install:
 
 script:
   - 'if [ "${TRAVIS_BUILD_DIR}" != "${GOPATH}/src/github.com/DeviaVir/terraform-provider-gsuite" ]; then ln -s "${TRAVIS_BUILD_DIR}" "${GOPATH}/src/github.com/DeviaVir/terraform-provider-gsuite"; fi'
+  - make test
   - make

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -215,6 +215,7 @@
     "helper/hashcode",
     "helper/hilmapstructure",
     "helper/logging",
+    "helper/pathorcontents",
     "helper/resource",
     "helper/schema",
     "moduledeps",
@@ -492,6 +493,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d29a9b323f6d5bd2ab4214fba04638c4bfd1aa72f1a9af33281d6d1ade52e4c0"
+  inputs-digest = "1b3ebb9000cfc4be6291ee05278a79d221b65293efdb5eb24ac7a06225be8753"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,12 @@ dev:
 		-tags "${GOTAGS}" \
 		-o "${PLUGIN_PATH}/terraform-provider-gsuite"
 
+# test runs all tests
+test:
+	go test -i $(TEST) || exit 1
+	echo $(TEST) | \
+		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+
 # dist builds the binaries and then signs and packages them for distribution
 dist:
 ifndef GPG_KEY

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ See the necessary oauth scopes both for service accounts and users below:
 - https://www.googleapis.com/auth/admin.directory.userschema
 - https://www.googleapis.com/auth/userinfo.email
 
+You could also provide the minimal set of scopes using the
+`oauth_scopes` variable in the provider configuration.
+
+```
+provider "gsuite" {
+  oauth_scopes = [
+    "https://www.googleapis.com/auth/admin.directory.group"
+  ]
+}
+```
+
 ### Using a service account
 
 Service accounts are great for automated workflows.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,46 @@
 
 This is a terraform provider for managing GSuite (Admin SDK) resources on Google
 
-## Setup
+## Authentication
+
+There are two possible authentication mechanisms for using this provider.
+Using a service account, or a personal admin account. The latter requires
+user interaction, whereas a service account could be used in an automated
+workflow.
+
+See the necessary oauth scopes both for service accounts and users below:
+- https://www.googleapis.com/auth/admin.directory.customer
+- https://www.googleapis.com/auth/admin.directory.group
+- https://www.googleapis.com/auth/admin.directory.orgunit
+- https://www.googleapis.com/auth/admin.directory.user
+- https://www.googleapis.com/auth/admin.directory.userschema
+- https://www.googleapis.com/auth/userinfo.email
+
+### Using a service account
+
+Service accounts are great for automated workflows.
+
+Only users with access to the Admin APIs can access the Admin SDK Directory API,
+therefore the service account needs to impersonate one of those users
+to access the Admin SDK Directory API.
+
+Follow the instruction at
+https://developers.google.com/admin-sdk/directory/v1/guides/delegation.
+
+Add `credentials` and `impersonated_user_email` when initializing the provider.
+```
+provider "gsuite" {
+  credentials = "./service-account.json"
+  impersonated_user_email = "admin@xxx.com"
+}
+```
+
+Credentials can also be provided via the following environment variables:
+- GOOGLE_CREDENTIALS
+- GOOGLE_CLOUD_KEYFILE_JSON
+- GCLOUD_KEYFILE_JSON
+
+### Using a personal administrator account
 
 In order to use the Admin SDK with a project, we will first need to create
 credentials for that project, you can do so here:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://developers.google.com/admin-sdk/directory/v1/guides/delegation.
 Add `credentials` and `impersonated_user_email` when initializing the provider.
 ```
 provider "gsuite" {
-  credentials = "./service-account.json"
+  credentials = "/full/path/service-account.json"
   impersonated_user_email = "admin@xxx.com"
 }
 ```

--- a/gsuite/config.go
+++ b/gsuite/config.go
@@ -47,6 +47,10 @@ func (c *Config) loadAndValidate() error {
 
 	var client *http.Client
 	if c.Credentials != "" {
+		if c.ImpersonatedUserEmail == "" {
+			return fmt.Errorf("required field missing: impersonated_user_email")
+		}
+
 		contents, _, err := pathorcontents.Read(c.Credentials)
 		if err != nil {
 			return fmt.Errorf("Error loading credentials: %s", err)

--- a/gsuite/config.go
+++ b/gsuite/config.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 )
 
-var oauthScopes = []string{
+var defaultOauthScopes = []string{
 	directory.AdminDirectoryCustomerScope,
 	directory.AdminDirectoryGroupScope,
 	directory.AdminDirectoryGroupMemberScope,
@@ -37,6 +37,8 @@ type Config struct {
 	// See https://developers.google.com/admin-sdk/directory/v1/guides/delegation
 	ImpersonatedUserEmail string
 
+	OauthScopes []string
+
 	directory *directory.Service
 }
 
@@ -44,6 +46,10 @@ type Config struct {
 // environment and creates a client for communicating with Google APIs.
 func (c *Config) loadAndValidate() error {
 	var account accountFile
+
+	oauthScopes := c.OauthScopes
+
+
 
 	var client *http.Client
 	if c.Credentials != "" {

--- a/gsuite/config.go
+++ b/gsuite/config.go
@@ -11,6 +11,11 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	directory "google.golang.org/api/admin/directory/v1"
+	"github.com/hashicorp/terraform/helper/pathorcontents"
+	"golang.org/x/oauth2/jwt"
+	"net/http"
+	"strings"
+	"encoding/json"
 )
 
 var oauthScopes = []string{
@@ -26,16 +31,58 @@ var oauthScopes = []string{
 
 // Config is the structure used to instantiate the GSuite provider.
 type Config struct {
+	Credentials string
+	// Only users with access to the Admin APIs can access the Admin SDK Directory API,
+	// therefore the service account needs to impersonate one of those users to access the Admin SDK Directory API.
+	// See https://developers.google.com/admin-sdk/directory/v1/guides/delegation
+	ImpersonatedUserEmail string
+
 	directory *directory.Service
 }
 
 // loadAndValidate loads the application default credentials from the
 // environment and creates a client for communicating with Google APIs.
 func (c *Config) loadAndValidate() error {
-	log.Printf("[INFO] authenticating with local client")
-	client, err := google.DefaultClient(context.Background(), oauthScopes...)
-	if err != nil {
-		return errors.Wrap(err, "failed to create client")
+	var account accountFile
+
+	var client *http.Client
+	if c.Credentials != "" {
+		contents, _, err := pathorcontents.Read(c.Credentials)
+		if err != nil {
+			return fmt.Errorf("Error loading credentials: %s", err)
+		}
+
+		//// Assume account_file is a JSON string
+		if err := parseJSON(&account, contents); err != nil {
+			return fmt.Errorf("Error parsing credentials '%s': %s", contents, err)
+		}
+
+		// Get the token for use in our requests
+		log.Printf("[INFO] Requesting Google token...")
+		log.Printf("[INFO]   -- Email: %s", account.ClientEmail)
+		log.Printf("[INFO]   -- Scopes: %s", oauthScopes)
+		log.Printf("[INFO]   -- Private Key Length: %d", len(account.PrivateKey))
+
+		conf := jwt.Config{
+			Email:      account.ClientEmail,
+			PrivateKey: []byte(account.PrivateKey),
+			Scopes:     oauthScopes,
+			TokenURL:   "https://accounts.google.com/o/oauth2/token",
+		}
+
+		conf.Subject = c.ImpersonatedUserEmail
+
+		// Initiate an http.Client. The following GET request will be
+		// authorized and authenticated on the behalf of
+		// your service account.
+		client = conf.Client(context.Background())
+	} else {
+		log.Printf("[INFO] Authenticating using DefaultClient")
+		err := error(nil)
+		client, err = google.DefaultClient(context.Background(), oauthScopes...)
+		if err != nil {
+			return errors.Wrap(err, "failed to create client")
+		}
 	}
 
 	// Use a custom user-agent string. This helps google with analytics and it's
@@ -53,4 +100,19 @@ func (c *Config) loadAndValidate() error {
 	c.directory = directorySvc
 
 	return nil
+}
+
+// accountFile represents the structure of the account file JSON file.
+type accountFile struct {
+	PrivateKeyId string `json:"private_key_id"`
+	PrivateKey   string `json:"private_key"`
+	ClientEmail  string `json:"client_email"`
+	ClientId     string `json:"client_id"`
+}
+
+func parseJSON(result interface{}, contents string) error {
+	r := strings.NewReader(contents)
+	dec := json.NewDecoder(r)
+
+	return dec.Decode(result)
 }

--- a/gsuite/config.go
+++ b/gsuite/config.go
@@ -52,7 +52,7 @@ func (c *Config) loadAndValidate() error {
 			return fmt.Errorf("Error loading credentials: %s", err)
 		}
 
-		//// Assume account_file is a JSON string
+		// Assume account_file is a JSON string
 		if err := parseJSON(&account, contents); err != nil {
 			return fmt.Errorf("Error parsing credentials '%s': %s", contents, err)
 		}

--- a/gsuite/config_test.go
+++ b/gsuite/config_test.go
@@ -1,0 +1,46 @@
+package gsuite
+
+import (
+"io/ioutil"
+"testing"
+)
+
+const testFakeCredentialsPath = "./test-fixtures/fake_account.json"
+
+func TestConfigLoadAndValidate_accountFilePath(t *testing.T) {
+	config := Config{
+		Credentials: testFakeCredentialsPath,
+		ImpersonatedUserEmail: "xxx@xxx.xom",
+	}
+
+	err := config.loadAndValidate()
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+}
+
+func TestConfigLoadAndValidate_accountFileJSON(t *testing.T) {
+	contents, err := ioutil.ReadFile(testFakeCredentialsPath)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	config := Config{
+		Credentials: string(contents),
+		ImpersonatedUserEmail: "xxx@xxx.xom",
+	}
+
+	err = config.loadAndValidate()
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+}
+
+func TestConfigLoadAndValidate_accountFileJSONInvalid(t *testing.T) {
+	config := Config{
+		Credentials: "{this is not json}",
+	}
+
+	if config.loadAndValidate() == nil {
+		t.Fatalf("expected error, but got nil")
+	}
+}

--- a/gsuite/config_test.go
+++ b/gsuite/config_test.go
@@ -1,8 +1,8 @@
 package gsuite
 
 import (
-"io/ioutil"
-"testing"
+	"io/ioutil"
+	"testing"
 )
 
 const testFakeCredentialsPath = "./test-fixtures/fake_account.json"
@@ -42,5 +42,34 @@ func TestConfigLoadAndValidate_accountFileJSONInvalid(t *testing.T) {
 
 	if config.loadAndValidate() == nil {
 		t.Fatalf("expected error, but got nil")
+	}
+}
+
+func TestConfigLoadAndValidate_noImpersonatedEmail(t *testing.T) {
+	// ImpersonatedUserEmail empty string when credentials set
+	config := Config{
+		Credentials: testFakeCredentialsPath,
+		ImpersonatedUserEmail: "",
+	}
+
+	err := config.loadAndValidate()
+	if err == nil {
+		t.Fatalf("error: %v", err)
+	}
+	if err.Error() != "required field missing: impersonated_user_email" {
+		t.Fatalf("error: %v", err)
+	}
+
+	// ImpersonatedUserEmail not provided when credentials set
+	config = Config{
+		Credentials: testFakeCredentialsPath,
+	}
+
+	err = config.loadAndValidate()
+	if err == nil {
+		t.Fatalf("error: %v", err)
+	}
+	if err.Error() != "required field missing: impersonated_user_email" {
+		t.Fatalf("error: %v", err)
 	}
 }

--- a/gsuite/provider.go
+++ b/gsuite/provider.go
@@ -51,14 +51,19 @@ func Provider() *schema.Provider {
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	credentials := d.Get("credentials").(string)
-	impersonatedUserEmail := d.Get("impersonated_user_email").(string)
-	oauthScopes := convertStringSet(d.Get("oauth_scopes").(*schema.Set))
+func oauthScopesFromConfigOrDefault(oauthScopesSet *schema.Set) []string {
+	oauthScopes := convertStringSet(oauthScopesSet)
 	if len(oauthScopes) == 0 {
 		log.Printf("[INFO] No Oauth Scopes provided. Using default oauth scopes.")
 		oauthScopes = defaultOauthScopes
 	}
+	return oauthScopes
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	credentials := d.Get("credentials").(string)
+	impersonatedUserEmail := d.Get("impersonated_user_email").(string)
+	oauthScopes := oauthScopesFromConfigOrDefault(d.Get("oauth_scopes").(*schema.Set))
 	config := Config{
 		Credentials: credentials,
 		ImpersonatedUserEmail: impersonatedUserEmail,

--- a/gsuite/provider_test.go
+++ b/gsuite/provider_test.go
@@ -1,0 +1,79 @@
+package gsuite
+
+import (
+"io/ioutil"
+"testing"
+
+"github.com/hashicorp/terraform/helper/schema"
+"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+var credsEnvVars = []string{
+	"GOOGLE_CREDENTIALS",
+	"GOOGLE_CLOUD_KEYFILE_JSON",
+	"GCLOUD_KEYFILE_JSON",
+}
+
+func init() {
+	testAccProvider = Provider()
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"gsuite": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func TestProvider_loadCredentialsFromFile(t *testing.T) {
+	ws, es := validateCredentials(testFakeCredentialsPath, "")
+	if len(ws) != 0 {
+		t.Errorf("Expected %d warnings, got %v", len(ws), ws)
+	}
+	if len(es) != 0 {
+		t.Errorf("Expected %d errors, got %v", len(es), es)
+	}
+}
+
+func TestProvider_loadCredentialsFromJSON(t *testing.T) {
+	contents, err := ioutil.ReadFile(testFakeCredentialsPath)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	ws, es := validateCredentials(string(contents), "")
+	if len(ws) != 0 {
+		t.Errorf("Expected %d warnings, got %v", len(ws), ws)
+	}
+	if len(es) != 0 {
+		t.Errorf("Expected %d errors, got %v", len(es), es)
+	}
+}
+
+func TestConfigOauthScopes(t *testing.T) {
+
+	scopes := oauthScopesFromConfigOrDefault(&schema.Set{})
+
+	if len(scopes) != len(defaultOauthScopes) {
+		t.Fatalf("error: default oauth scopes not being set")
+	}
+
+	s := schema.NewSet(
+		schema.HashString,
+		[]interface{}{
+			"https://www.googleapis.com/auth/admin.directory.group"})
+
+	scopes = oauthScopesFromConfigOrDefault(s)
+
+	if len(scopes) != len(convertStringSet(s)) {
+		t.Fatalf("error: oauth scopes not being set")
+	}
+}

--- a/gsuite/resource_user.go
+++ b/gsuite/resource_user.go
@@ -349,7 +349,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 			userPosix.Gecos = posixConfig["gecos"].(string)
 		}
 		if posixConfig["gid"] != 0 {
-			log.Printf("[DEBUG] Setting posix %d gid: %v", i, uint64(posixConfig["gid"].(int)))
+			log.Printf("[DEBUG] Setting posix %d gid: %d", i, uint64(posixConfig["gid"].(int)))
 			userPosix.Gid = uint64(posixConfig["gid"].(int))
 		}
 		if posixConfig["home_directory"] != "" {
@@ -369,7 +369,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 			userPosix.Primary = posixConfig["primary"].(bool)
 		}
 		if posixConfig["uid"] != 0 {
-			log.Printf("[DEBUG] Setting posix %d uid: %v", i, uint64(posixConfig["uid"].(int)))
+			log.Printf("[DEBUG] Setting posix %d uid: %d", i, uint64(posixConfig["uid"].(int)))
 			userPosix.Uid = uint64(posixConfig["uid"].(int))
 		}
 		if posixConfig["username"] != "" {
@@ -535,7 +535,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 				userPosix.Gecos = posixConfig["gecos"].(string)
 			}
 			if posixConfig["gid"] != 0 {
-				log.Printf("[DEBUG] Setting posix %d gid: %v", i, uint64(posixConfig["gid"].(int)))
+				log.Printf("[DEBUG] Setting posix %d gid: %d", i, uint64(posixConfig["gid"].(int)))
 				userPosix.Gid = uint64(posixConfig["gid"].(int))
 			}
 			if posixConfig["home_directory"] != "" {
@@ -555,7 +555,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 				userPosix.Primary = posixConfig["primary"].(bool)
 			}
 			if posixConfig["uid"] != 0 {
-				log.Printf("[DEBUG] Setting posix %d uid: %v", i, uint64(posixConfig["uid"].(int)))
+				log.Printf("[DEBUG] Setting posix %d uid: %d", i, uint64(posixConfig["uid"].(int)))
 				userPosix.Uid = uint64(posixConfig["uid"].(int))
 			}
 			if posixConfig["username"] != "" {

--- a/gsuite/resource_user.go
+++ b/gsuite/resource_user.go
@@ -303,19 +303,19 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 
 	if v, ok := d.GetOk("change_password_next_login"); ok {
-		log.Printf("[DEBUG] Setting %s: %s", "change_password_next_login", v.(bool))
+		log.Printf("[DEBUG] Setting %s: %t", "change_password_next_login", v.(bool))
 		user.ChangePasswordAtNextLogin = v.(bool)
 	}
 	if v, ok := d.GetOk("include_in_global_list"); ok {
-		log.Printf("[DEBUG] Setting %s: %s", "include_in_global_list", v.(bool))
+		log.Printf("[DEBUG] Setting %s: %t", "include_in_global_list", v.(bool))
 		user.IncludeInGlobalAddressList = v.(bool)
 	}
 	if v, ok := d.GetOk("is_ip_whitelisted"); ok {
-		log.Printf("[DEBUG] Setting %s: %s", "is_ip_whitelisted", v.(bool))
+		log.Printf("[DEBUG] Setting %s: %t", "is_ip_whitelisted", v.(bool))
 		user.IpWhitelisted = v.(bool)
 	}
 	if v, ok := d.GetOk("is_suspended"); ok {
-		log.Printf("[DEBUG] Setting %s: %s", "is_suspended", v.(bool))
+		log.Printf("[DEBUG] Setting %s: %t", "is_suspended", v.(bool))
 		user.Suspended = v.(bool)
 	}
 
@@ -326,7 +326,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 		userSsh := &directory.UserSshPublicKey{}
 
 		if v, ok := sshConfig["expiration_time_usec"]; ok {
-			log.Printf("[DEBUG] Setting ssh %d expiration_time_usec: %s", i, int64(v.(int)))
+			log.Printf("[DEBUG] Setting ssh %d expiration_time_usec: %v", i, int64(v.(int)))
 			userSsh.ExpirationTimeUsec = int64(v.(int))
 		}
 		if v, ok := sshConfig["key"]; ok {
@@ -349,7 +349,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 			userPosix.Gecos = posixConfig["gecos"].(string)
 		}
 		if posixConfig["gid"] != 0 {
-			log.Printf("[DEBUG] Setting posix %d gid: %s", i, uint64(posixConfig["gid"].(int)))
+			log.Printf("[DEBUG] Setting posix %d gid: %v", i, uint64(posixConfig["gid"].(int)))
 			userPosix.Gid = uint64(posixConfig["gid"].(int))
 		}
 		if posixConfig["home_directory"] != "" {
@@ -365,11 +365,11 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 			userPosix.Shell = posixConfig["shell"].(string)
 		}
 		if posixConfig["primary"] != "" {
-			log.Printf("[DEBUG] Setting posix %d primary: %s", i, posixConfig["primary"].(bool))
+			log.Printf("[DEBUG] Setting posix %d primary: %t", i, posixConfig["primary"].(bool))
 			userPosix.Primary = posixConfig["primary"].(bool)
 		}
 		if posixConfig["uid"] != 0 {
-			log.Printf("[DEBUG] Setting posix %d uid: %s", i, uint64(posixConfig["uid"].(int)))
+			log.Printf("[DEBUG] Setting posix %d uid: %v", i, uint64(posixConfig["uid"].(int)))
 			userPosix.Uid = uint64(posixConfig["uid"].(int))
 		}
 		if posixConfig["username"] != "" {
@@ -463,7 +463,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("change_password_next_login") {
 		if v, ok := d.GetOk("change_password_next_login"); ok {
-			log.Printf("[DEBUG] Updating user change_password_next_login: %s", d.Get("change_password_next_login").(bool))
+			log.Printf("[DEBUG] Updating user change_password_next_login: %t", d.Get("change_password_next_login").(bool))
 			user.ChangePasswordAtNextLogin = v.(bool)
 		} else {
 			log.Printf("[DEBUG] Removing user change_password_next_login")
@@ -473,7 +473,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if d.HasChange("include_in_global_list") {
 		if v, ok := d.GetOk("include_in_global_list"); ok {
-			log.Printf("[DEBUG] Updating user include_in_global_list: %s", d.Get("include_in_global_list").(bool))
+			log.Printf("[DEBUG] Updating user include_in_global_list: %t", d.Get("include_in_global_list").(bool))
 			user.IncludeInGlobalAddressList = v.(bool)
 		} else {
 			log.Printf("[DEBUG] Removing user include_in_global_list")
@@ -483,7 +483,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if d.HasChange("is_ip_whitelisted") {
 		if v, ok := d.GetOk("is_ip_whitelisted"); ok {
-			log.Printf("[DEBUG] Updating user is_ip_whitelisted: %s", d.Get("is_ip_whitelisted").(bool))
+			log.Printf("[DEBUG] Updating user is_ip_whitelisted: %t", d.Get("is_ip_whitelisted").(bool))
 			user.IpWhitelisted = v.(bool)
 		} else {
 			log.Printf("[DEBUG] Removing user is_ip_whitelisted")
@@ -493,7 +493,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if d.HasChange("is_suspended") {
 		if v, ok := d.GetOk("is_suspended"); ok {
-			log.Printf("[DEBUG] Updating user is_suspended: %s", d.Get("is_suspended").(bool))
+			log.Printf("[DEBUG] Updating user is_suspended: %t", d.Get("is_suspended").(bool))
 			user.Suspended = v.(bool)
 		} else {
 			log.Printf("[DEBUG] Removing user is_suspended")
@@ -510,7 +510,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 			userSsh := &directory.UserSshPublicKey{}
 
 			if v, ok := sshConfig["expiration_time_usec"]; ok {
-				log.Printf("[DEBUG] Setting ssh %d expiration_time_usec: %s", i, int64(v.(int)))
+				log.Printf("[DEBUG] Setting ssh %d expiration_time_usec: %v", i, int64(v.(int)))
 				userSsh.ExpirationTimeUsec = int64(v.(int))
 			}
 			if v, ok := sshConfig["key"]; ok {
@@ -535,7 +535,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 				userPosix.Gecos = posixConfig["gecos"].(string)
 			}
 			if posixConfig["gid"] != 0 {
-				log.Printf("[DEBUG] Setting posix %d gid: %s", i, uint64(posixConfig["gid"].(int)))
+				log.Printf("[DEBUG] Setting posix %d gid: %v", i, uint64(posixConfig["gid"].(int)))
 				userPosix.Gid = uint64(posixConfig["gid"].(int))
 			}
 			if posixConfig["home_directory"] != "" {
@@ -551,11 +551,11 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 				userPosix.Shell = posixConfig["shell"].(string)
 			}
 			if posixConfig["primary"] != "" {
-				log.Printf("[DEBUG] Setting posix %d primary: %s", i, posixConfig["primary"].(bool))
+				log.Printf("[DEBUG] Setting posix %d primary: %t", i, posixConfig["primary"].(bool))
 				userPosix.Primary = posixConfig["primary"].(bool)
 			}
 			if posixConfig["uid"] != 0 {
-				log.Printf("[DEBUG] Setting posix %d uid: %s", i, uint64(posixConfig["uid"].(int)))
+				log.Printf("[DEBUG] Setting posix %d uid: %v", i, uint64(posixConfig["uid"].(int)))
 				userPosix.Uid = uint64(posixConfig["uid"].(int))
 			}
 			if posixConfig["username"] != "" {

--- a/gsuite/test-fixtures/fake_account.json
+++ b/gsuite/test-fixtures/fake_account.json
@@ -1,0 +1,7 @@
+{
+"private_key_id": "foo",
+"private_key": "bar",
+"client_email": "foo@bar.com",
+"client_id": "id@foo.com",
+"type": "service_account"
+}

--- a/gsuite/utils.go
+++ b/gsuite/utils.go
@@ -54,3 +54,11 @@ func mergeSchemas(a, b map[string]*schema.Schema) map[string]*schema.Schema {
 
 	return merged
 }
+
+func convertStringSet(set *schema.Set) []string {
+	s := make([]string, 0, set.Len())
+	for _, v := range set.List() {
+		s = append(s, v.(string))
+	}
+	return s
+}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/deviavir/terraform-provider-gsuite/gsuite"
+	"github.com/DeviaVir/terraform-provider-gsuite/gsuite"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/DeviaVir/terraform-provider-gsuite/gsuite"
+	"github.com/deviavir/terraform-provider-gsuite/gsuite"
 )
 
 func main() {


### PR DESCRIPTION
It is mostly based on the Google provider.

Additional configurations were taken from https://developers.google.com/admin-sdk/directory/v1/guides/delegation

The optional provider configuration looks like this:
```
provider "gsuite" {
  credentials = "${file("./service-account.json")}"
  //credentials = "./service-account.json"
  impersonated_user_email = "admin@xxx.com"
}
```