### PR TITLE
Skip the return on hasMember, immediately create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOVERSION := 1.9.3
 PROJECT := $(CURRENT_DIR:$(GOPATH)/src/%=%)
 OWNER := $(notdir $(patsubst %/,%,$(dir $(PROJECT))))
 NAME := $(notdir $(PROJECT))
-VERSION := 0.1.5
+VERSION := 0.1.6
 EXTERNAL_TOOLS = \
 	github.com/golang/dep/cmd/dep
 

--- a/gsuite/resource_group_members.go
+++ b/gsuite/resource_group_members.go
@@ -313,7 +313,7 @@ func upsertMember(email, groupEmail, role string, config *Config) error {
 			return err
 		})
 		if err != nil {
-			return fmt.Errorf("Error checking hasmember: %s, %s", err, email)
+			//return fmt.Errorf("Error checking hasmember: %s, %s", err, email)
 		}
 
 		if hasMemberResponse.IsMember == true {

--- a/gsuite/resource_group_members.go
+++ b/gsuite/resource_group_members.go
@@ -313,7 +313,7 @@ func upsertMember(email, groupEmail, role string, config *Config) error {
 			return err
 		})
 		if err != nil {
-			return createGroupMember(email, groupEmail, role, config)
+			return createGroupMember(groupMember, groupEmail, config)
 		}
 
 		if hasMemberResponse.IsMember == true {
@@ -327,25 +327,21 @@ func upsertMember(email, groupEmail, role string, config *Config) error {
 			}
 			log.Printf("[INFO] Updated groupMember: %s", updatedGroupMember.Email)
 		} else {
-			return createGroupMember(email, groupEmail, role, config)
+			return createGroupMember(groupMember, groupEmail, config)
 		}
 	}
 
 	return nil
 }
 
-func createGroupMember(email string, groupEmail string, role string, config *Config) (err error) {
-	groupMember := &directory.Member{
-		Role:  role,
-		Email: email,
-	}
+func createGroupMember(groupMember *directory.Member, groupEmail string, config *Config) (err error) {
 	var createdGroupMember *directory.Member
 	err = retry(func() error {
 		createdGroupMember, err = config.directory.Members.Insert(groupEmail, groupMember).Do()
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("Error creating groupMember: %s, %s", err, email)
+		return fmt.Errorf("Error creating groupMember: %s, %s", err, groupMember.Email)
 	}
 	log.Printf("[INFO] Created groupMember: %s", createdGroupMember.Email)
 


### PR DESCRIPTION
fixes https://github.com/DeviaVir/terraform-provider-gsuite/issues/23

If the hasMember check fails, since the member is unknown (or external) we should still allow it to continue.