### PR TITLE
Group member: add a member that exists from a manual addition

### DIFF
--- a/gsuite/resource_group_member.go
+++ b/gsuite/resource_group_member.go
@@ -110,10 +110,9 @@ func resourceGroupMemberCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 		log.Printf("[INFO] found existing group member %s", locatedGroupMember.Email)
 
-		var updatedGroupMember *directory.Member
 		var err error
 		err = retry(func() error {
-			updatedGroupMember, err = config.directory.Members.Patch(group, locatedGroupMember.Id, groupMember).Do()
+			_, err = config.directory.Members.Patch(group, locatedGroupMember.Id, groupMember).Do()
 			return err
 		})
 

--- a/gsuite/resource_group_member.go
+++ b/gsuite/resource_group_member.go
@@ -85,11 +85,48 @@ func resourceGroupMemberCreate(d *schema.ResourceData, meta interface{}) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("error creating group member: %s", err)
+		if !strings.Contains(err.Error(), "Member already exists") {
+			return fmt.Errorf("error creating group member: %s", err)
+		}
+		log.Printf("[INFO] %s already part of this group. attempting to update", groupMember.Email)
+
+		var existingGroupMembers *directory.Members
+		err = retry(func() error {
+			existingGroupMembers, err = config.directory.Members.List(group).Do()
+			return err
+		})
+		if err != nil {
+			return fmt.Errorf("error locating existing group members: %s", err)
+		}
+		var locatedGroupMember *directory.Member
+		for _, existingGroupMember := range existingGroupMembers.Members {
+			if existingGroupMember.Email == groupMember.Email {
+				locatedGroupMember = existingGroupMember
+				break
+			}
+		}
+		if locatedGroupMember == nil {
+			return fmt.Errorf("error locating existing group member %s", groupMember.Email)
+		}
+		log.Printf("[INFO] found existing group member %s", locatedGroupMember.Email)
+
+		var updatedGroupMember *directory.Member
+		var err error
+		err = retry(func() error {
+			updatedGroupMember, err = config.directory.Members.Patch(group, locatedGroupMember.Id, groupMember).Do()
+			return err
+		})
+
+		if err != nil {
+			return fmt.Errorf("error updating existing group member: %s", err)
+		}
+		log.Printf("[INFO] Updated group member: %s", groupMember.Email)
+		d.SetId(locatedGroupMember.Id)
+	} else {
+		log.Printf("[INFO] Created group member: %s", createdGroupMember.Email)
+		d.SetId(createdGroupMember.Id)
 	}
 
-	d.SetId(createdGroupMember.Id)
-	log.Printf("[INFO] Created group member: %s", createdGroupMember.Email)
 	return resourceGroupMemberRead(d, meta)
 }
 


### PR DESCRIPTION
**Summary:**

When adding a member to a group and that member has already been added manually by a group manager, `google.golang.org/api/admin/directory/v1` throws a `Member already exists` error.

**Reproduce:**

* Have a group manager add user `a@b.com` to an existing google group
* Add membership for that user in terraform
```
resource "gsuite_group_member" "some_manager" {
  group = "yourgroup@google"
  email = "a@b.com"
  role  = "MANAGER"
}
```
* terraform apply

**Error Encountered:**

```
  * gsuite_group_member.some_manager: 1 error(s) occurred:
  * gsuite_group_member.some_manager: error creating group member: googleapi: Error 409: Member already exists., duplicate
```

**Suggested Patch:**

Since the user is not originally managed by terraform, the user is attempted to be created.
* Check if directory api return `err.Error()` contains `"Member already exists"`
* Get the list of existing users, and get `Member.Id` when finding a matching email address
* Use located `Member.Id` along with terraform parameters such as role and submit patch to ensure user is in the appropriate role
* Set terraform resource Id in the state file

**Alternatives:**

* Returned errors could be type asserted as googleapi.Error and then check for an exact string map, but seems brittle if internal googleapi.Error structure changes and `"Member already exists"` seems fairly distinct.
