### PR TITLE
Domain resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,6 @@ https://www.googleapis.com/auth/admin.directory.user,
 Now that you have a credential that is allowed to the Admin SDK, you can use the
 G Suite provider.
 
-## Configuration
-
-Your G Suite Customer ID is required for some Admins SDK Directory APIs,
-therefore add also `customer_id` when initializing the provider.
-
-```
-provider "gsuite" {
-  customer_id = "xxxxxxxx"
-}
-```
-
 ## Installation
 
 1. Download the latest compiled binary from [GitHub releases](https://github.com/DeviaVir/terraform-provider-gsuite/releases).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Terraform GSuite Provider
+# Terraform G Suite Provider
 
-This is a terraform provider for managing GSuite (Admin SDK) resources on Google
+This is a terraform provider for managing G Suite (Admin SDK) resources on Google
 
 ## Authentication
 
@@ -77,7 +77,18 @@ https://www.googleapis.com/auth/admin.directory.user,
 ```
 
 Now that you have a credential that is allowed to the Admin SDK, you can use the
-GSuite provider.
+G Suite provider.
+
+## Configuration
+
+Your G Suite Customer ID is required for some Admins SDK Directory APIs,
+therefore add also `customer_id` when initializing the provider.
+
+```
+provider "gsuite" {
+  customer_id = "xxxxxxxx"
+}
+```
 
 ## Installation
 

--- a/examples/domain/domain.tf
+++ b/examples/domain/domain.tf
@@ -1,0 +1,3 @@
+resource "gsuite_domain" "my_domain" {
+  domain_name = "example.com"
+}

--- a/gsuite/config.go
+++ b/gsuite/config.go
@@ -22,7 +22,6 @@ var defaultOauthScopes = []string{
 	directory.AdminDirectoryGroupScope,
 	directory.AdminDirectoryUserScope,
 	directory.AdminDirectoryUserschemaScope,
-	directory.AdminDirectoryDomainScope,
 }
 
 // Config is the structure used to instantiate the GSuite provider.

--- a/gsuite/config.go
+++ b/gsuite/config.go
@@ -22,6 +22,7 @@ var defaultOauthScopes = []string{
 	directory.AdminDirectoryGroupScope,
 	directory.AdminDirectoryUserScope,
 	directory.AdminDirectoryUserschemaScope,
+	directory.AdminDirectoryDomainScope,
 }
 
 // Config is the structure used to instantiate the GSuite provider.
@@ -31,6 +32,8 @@ type Config struct {
 	// therefore the service account needs to impersonate one of those users to access the Admin SDK Directory API.
 	// See https://developers.google.com/admin-sdk/directory/v1/guides/delegation
 	ImpersonatedUserEmail string
+
+	CustomerId string
 
 	OauthScopes []string
 

--- a/gsuite/provider.go
+++ b/gsuite/provider.go
@@ -47,7 +47,7 @@ func Provider() *schema.Provider {
 			"gsuite_user_schema":   resourceUserSchema(),
 			"gsuite_group_member":  resourceGroupMember(),
 			"gsuite_group_members": resourceGroupMembers(),
-			"gsuite_domain": 				resourceDomain(),
+			"gsuite_domain":        resourceDomain(),
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -76,10 +76,15 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
+	// There shouldn't be the need to setup customer ID in the configuration,
+	// but leaving the possibility to specify it explictly.
+	// By default we use my_customer as customer ID, which means the API will use
+	// the G Suite customer ID associated with the impersonating account.
 	if v, ok := d.GetOk("customer_id"); ok {
 		customerId = v.(string)
 	} else {
-		log.Printf("[WARN] No Customer ID provided. It is required for some resources.")
+		log.Printf("[INFO] No Customer ID provided. Using my_customer.")
+		customerId = "my_customer"
 	}
 
 	oauthScopes := oauthScopesFromConfigOrDefault(d.Get("oauth_scopes").(*schema.Set))

--- a/gsuite/resource_domain.go
+++ b/gsuite/resource_domain.go
@@ -1,0 +1,150 @@
+package gsuite
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	directory "google.golang.org/api/admin/directory/v1"
+)
+
+func resourceDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDomainCreate,
+		Read:   resourceDomainRead,
+		Delete: resourceDomainDelete,
+		Update: resourceDomainUpdate,
+
+		Schema: map[string]*schema.Schema{
+
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"domain_aliases": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
+			},
+
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"is_primary": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+		},
+	}
+}
+
+func resourceDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	domain := &directory.Domains{}
+	customerId := config.CustomerId
+
+	if v, ok := d.GetOk("domain_name"); ok {
+		log.Printf("[DEBUG] Setting %s: %s", "domain_name", v.(string))
+		domain.DomainName = strings.ToLower(v.(string))
+	}
+
+	var createdDomain *directory.Domains
+
+	var err error
+	err = retry(func() error {
+		createdDomain, err = config.directory.Domains.Insert(customerId, domain).Do()
+		return err
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error creating domain: %s", err)
+	}
+
+	// There is no id as such for a Domain resource, therefore we use
+	// DomainName as unique identifier.
+	d.SetId(createdDomain.DomainName)
+
+	log.Printf("[INFO] Created domain: %s", createdDomain.DomainName)
+	return resourceDomainRead(d, meta)
+}
+
+
+func resourceDomainRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	customerId := config.CustomerId
+	var domain *directory.Domains
+
+	var domainName string
+
+	if v, ok := d.GetOk("domain_name"); ok {
+		log.Printf("[DEBUG] Reading %s: %s", "domain_name", v.(string))
+		domainName = v.(string)
+	}
+
+	var err error
+	err = retry(func() error {
+		domain, err = config.directory.Domains.Get(customerId, domainName).Do()
+		return err
+	})
+
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Domain %q", d.Get("domain_name").(string)))
+	}
+
+	d.SetId(domain.DomainName)
+	d.Set("domain_name", domain.DomainName)
+	d.Set("domain_aliases", domain.DomainAliases)
+	d.Set("etag", domain.Etag)
+	d.Set("is_primary", domain.IsPrimary)
+	d.Set("creation_time", domain.CreationTime)
+
+	return nil
+}
+
+func resourceDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	customerId := config.CustomerId
+
+	var domainName string
+
+	if v, ok := d.GetOk("domain_name"); ok {
+		log.Printf("[DEBUG] Deleting %s: %s", "domain_name", v.(string))
+		domainName = v.(string)
+	}
+
+	var err error
+	err = retry(func() error {
+		err = config.directory.Domains.Delete(customerId, domainName).Do()
+		return err
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error deleting domain: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+		// There is no update method in https://developers.google.com/admin-sdk/directory/v1/reference/domains,
+		// therefore returning an error message to the user.
+		return fmt.Errorf("There is no update method for gsuite_domain resource")
+}

--- a/gsuite/resource_domain.go
+++ b/gsuite/resource_domain.go
@@ -14,7 +14,7 @@ func resourceDomain() *schema.Resource {
 		Create: resourceDomainCreate,
 		Read:   resourceDomainRead,
 		Delete: resourceDomainDelete,
-		Update: resourceDomainUpdate,
+		// There is no update method
 
 		Schema: map[string]*schema.Schema{
 
@@ -23,15 +23,10 @@ func resourceDomain() *schema.Resource {
 				Computed: true,
 			},
 
-			"domain_aliases": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-
 			"domain_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 				StateFunc: func(val interface{}) string {
 					return strings.ToLower(val.(string))
 				},
@@ -41,17 +36,12 @@ func resourceDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
-			"is_primary": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-
 		},
 	}
 }
 
 func resourceDomainCreate(d *schema.ResourceData, meta interface{}) error {
+
 	config := meta.(*Config)
 
 	domain := &directory.Domains{}
@@ -77,13 +67,14 @@ func resourceDomainCreate(d *schema.ResourceData, meta interface{}) error {
 	// There is no id as such for a Domain resource, therefore we use
 	// DomainName as unique identifier.
 	d.SetId(createdDomain.DomainName)
+	d.Set("domain_name", domain.DomainName)
 
 	log.Printf("[INFO] Created domain: %s", createdDomain.DomainName)
 	return resourceDomainRead(d, meta)
 }
 
-
 func resourceDomainRead(d *schema.ResourceData, meta interface{}) error {
+
 	config := meta.(*Config)
 
 	customerId := config.CustomerId
@@ -108,15 +99,12 @@ func resourceDomainRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(domain.DomainName)
 	d.Set("domain_name", domain.DomainName)
-	d.Set("domain_aliases", domain.DomainAliases)
-	d.Set("etag", domain.Etag)
-	d.Set("is_primary", domain.IsPrimary)
-	d.Set("creation_time", domain.CreationTime)
 
 	return nil
 }
 
 func resourceDomainDelete(d *schema.ResourceData, meta interface{}) error {
+
 	config := meta.(*Config)
 
 	customerId := config.CustomerId
@@ -141,10 +129,4 @@ func resourceDomainDelete(d *schema.ResourceData, meta interface{}) error {
 	d.SetId("")
 
 	return nil
-}
-
-func resourceDomainUpdate(d *schema.ResourceData, meta interface{}) error {
-		// There is no update method in https://developers.google.com/admin-sdk/directory/v1/reference/domains,
-		// therefore returning an error message to the user.
-		return fmt.Errorf("There is no update method for gsuite_domain resource")
 }

--- a/gsuite/utils.go
+++ b/gsuite/utils.go
@@ -34,7 +34,7 @@ func retryTime(retryFunc func() error, minutes int) error {
 		if err == nil {
 			return nil
 		}
-		if gerr, ok := err.(*googleapi.Error); ok && (gerr.Errors[0].Reason == "quotaExceeded" || gerr.Code == 404 || gerr.Code == 429 || gerr.Code == 500 || gerr.Code == 502 || gerr.Code == 503) {
+		if gerr, ok := err.(*googleapi.Error); ok && (gerr.Errors[0].Reason == "quotaExceeded" || gerr.Code == 404 || gerr.Code == 409 || gerr.Code == 429 || gerr.Code == 500 || gerr.Code == 502 || gerr.Code == 503) {
 			return resource.RetryableError(gerr)
 		}
 		return resource.NonRetryableError(err)


### PR DESCRIPTION
I added a new resource for domain. The reference Admin SDK Directory API is https://developers.google.com/admin-sdk/directory/v1/reference/domains.
It is now possible to insert/read/delete domains.

I have also added the option to add `customer_id` in the provider configuration.  This would be the G Suite customer ID, which is required for Domains and also other G Suite Admin SDK Directory APIs.

