### PR TITLE
data: group & user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOVERSION := 1.12
 PROJECT := github.com/DeviaVir/terraform-provider-gsuite
 OWNER := $(notdir $(patsubst %/,%,$(dir $(PROJECT))))
 NAME := $(notdir $(PROJECT))
-VERSION := 0.1.18
+VERSION := 0.1.18-1
 EXTERNAL_TOOLS = \
 	github.com/golang/dep/cmd/dep
 

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ GOTAGS ?=
 GOMAXPROCS ?= 8
 
 # Get the project metadata
-GOVERSION := 1.11
+GOVERSION := 1.12
 PROJECT := github.com/DeviaVir/terraform-provider-gsuite
 OWNER := $(notdir $(patsubst %/,%,$(dir $(PROJECT))))
 NAME := $(notdir $(PROJECT))
-VERSION := 0.1.17
+VERSION := 0.1.18
 EXTERNAL_TOOLS = \
 	github.com/golang/dep/cmd/dep
 

--- a/gsuite/data_group.go
+++ b/gsuite/data_group.go
@@ -11,7 +11,7 @@ func dataGroup() *schema.Resource {
 	return &schema.Resource{
 		Read: dataGroupRead,
 		Schema: map[string]*schema.Schema{
-      "email": {
+			"email": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -60,7 +60,7 @@ func dataGroup() *schema.Resource {
 }
 
 func dataGroupRead(d *schema.ResourceData, meta interface{}) error {
-  config := meta.(*Config)
+	config := meta.(*Config)
 
 	var group *directory.Group
 	var err error

--- a/gsuite/data_group.go
+++ b/gsuite/data_group.go
@@ -1,0 +1,88 @@
+package gsuite
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	directory "google.golang.org/api/admin/directory/v1"
+)
+
+func dataGroup() *schema.Resource {
+	return &schema.Resource{
+		Read: dataGroupRead,
+		Schema: map[string]*schema.Schema{
+      "email": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"aliases": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"direct_members_count": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"admin_created": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"non_editable_aliases": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"member": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: schemaGroupMembers,
+				},
+			},
+		},
+	}
+}
+
+func dataGroupRead(d *schema.ResourceData, meta interface{}) error {
+  config := meta.(*Config)
+
+	var group *directory.Group
+	var err error
+	err = retry(func() error {
+		group, err = config.directory.Groups.Get(d.Get("email").(string)).Do()
+		return err
+	})
+
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Group %q", d.Get("name").(string)))
+	}
+
+	members, err := getAPIMembers(d.Get("email").(string), config)
+
+	d.SetId(group.Id)
+	d.Set("name", group.Name)
+	d.Set("description", group.Description)
+	d.Set("direct_members_count", group.DirectMembersCount)
+	d.Set("admin_created", group.AdminCreated)
+	d.Set("aliases", group.Aliases)
+	d.Set("non_editable_aliases", group.NonEditableAliases)
+	d.Set("member", membersToCfg(members))
+
+	return nil
+}

--- a/gsuite/data_user.go
+++ b/gsuite/data_user.go
@@ -1,18 +1,18 @@
 package gsuite
 
 import (
-  "strings"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-  directory "google.golang.org/api/admin/directory/v1"
+	directory "google.golang.org/api/admin/directory/v1"
 )
 
 func dataUser() *schema.Resource {
 	return &schema.Resource{
 		Read: dataUserRead,
 		Schema: map[string]*schema.Schema{
-      "primary_email": {
+			"primary_email": {
 				Type:     schema.TypeString,
 				Required: true,
 				StateFunc: func(val interface{}) string {
@@ -20,7 +20,7 @@ func dataUser() *schema.Resource {
 				},
 			},
 
-      "aliases": {
+			"aliases": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -225,7 +225,7 @@ func dataUser() *schema.Resource {
 }
 
 func dataUserRead(d *schema.ResourceData, meta interface{}) error {
-  config := meta.(*Config)
+	config := meta.(*Config)
 
 	var user *directory.User
 	var err error

--- a/gsuite/data_user.go
+++ b/gsuite/data_user.go
@@ -1,0 +1,269 @@
+package gsuite
+
+import (
+  "strings"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+  directory "google.golang.org/api/admin/directory/v1"
+)
+
+func dataUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataUserRead,
+		Schema: map[string]*schema.Schema{
+      "primary_email": {
+				Type:     schema.TypeString,
+				Required: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
+			},
+
+      "aliases": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"agreed_to_terms": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"change_password_next_login": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"creation_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"customer_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"deletion_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"include_in_global_list": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"is_ip_whitelisted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"is_admin": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"is_delegated_admin": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"2s_enforced": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"2s_enrolled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"is_mailbox_setup": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"last_login_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"family_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"full_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"given_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"password": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			// md5, sha-1 and crypt
+			"hash_function": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"posix_accounts": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gecos": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"gid": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"home_directory": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"shell": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"system_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"primary": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"uid": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"username": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"ssh_public_keys": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"expiration_time_usec": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fingerprint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"is_suspended": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"suspension_reason": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"custom_schema": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataUserRead(d *schema.ResourceData, meta interface{}) error {
+  config := meta.(*Config)
+
+	var user *directory.User
+	var err error
+	err = retry(func() error {
+		user, err = config.directory.Users.Get(d.Get("primary_email").(string)).Do()
+		return err
+	})
+
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("User %q", d.Id()))
+	}
+
+	d.SetId(user.Id)
+	d.Set("deletion_time", user.DeletionTime)
+	d.Set("primary_email", user.PrimaryEmail)
+	d.Set("password", user.Password)
+	d.Set("hash_function", user.HashFunction)
+	d.Set("suspension_reason", user.SuspensionReason)
+	d.Set("change_password_next_login", user.ChangePasswordAtNextLogin)
+	d.Set("include_in_global_list", user.IncludeInGlobalAddressList)
+	d.Set("is_ip_whitelisted", user.IpWhitelisted)
+	d.Set("is_admin", user.IsAdmin)
+	d.Set("is_delegated_admin", user.IsDelegatedAdmin)
+	d.Set("is_suspended", user.Suspended)
+	d.Set("2s_enrolled", user.IsEnrolledIn2Sv)
+	d.Set("2s_enforced", user.IsEnforcedIn2Sv)
+	d.Set("aliases", user.Aliases)
+	d.Set("agreed_to_terms", user.AgreedToTerms)
+	d.Set("creation_time", user.CreationTime)
+	d.Set("customer_id", user.CustomerId)
+	d.Set("etag", user.Etag)
+	d.Set("last_login_time", user.LastLoginTime)
+	d.Set("is_mailbox_setup", user.IsMailboxSetup)
+
+	d.Set("name", flattenUserName(user.Name))
+	d.Set("posix_accounts", user.PosixAccounts)
+	d.Set("ssh_public_keys", user.SshPublicKeys)
+	d.Set("custom_schema", user.CustomSchemas)
+
+	return nil
+}

--- a/gsuite/provider.go
+++ b/gsuite/provider.go
@@ -39,8 +39,8 @@ func Provider() *schema.Provider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"gsuite_group": dataGroup(),
-			"gsuite_user": dataUser(),
+			"gsuite_group":           dataGroup(),
+			"gsuite_user":            dataUser(),
 			"gsuite_user_attributes": dataUserAttributes(),
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/gsuite/provider.go
+++ b/gsuite/provider.go
@@ -39,15 +39,17 @@ func Provider() *schema.Provider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"gsuite_group": dataGroup(),
+			"gsuite_user": dataUser(),
 			"gsuite_user_attributes": dataUserAttributes(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"gsuite_domain":        resourceDomain(),
 			"gsuite_group":         resourceGroup(),
-			"gsuite_user":          resourceUser(),
-			"gsuite_user_schema":   resourceUserSchema(),
 			"gsuite_group_member":  resourceGroupMember(),
 			"gsuite_group_members": resourceGroupMembers(),
-			"gsuite_domain":        resourceDomain(),
+			"gsuite_user":          resourceUser(),
+			"gsuite_user_schema":   resourceUserSchema(),
 		},
 		ConfigureFunc: providerConfigure,
 	}
@@ -64,7 +66,7 @@ func oauthScopesFromConfigOrDefault(oauthScopesSet *schema.Set) []string {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	var impersonatedUserEmail string
-	var customerId string
+	var customerID string
 
 	credentials := d.Get("credentials").(string)
 
@@ -81,10 +83,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	// By default we use my_customer as customer ID, which means the API will use
 	// the G Suite customer ID associated with the impersonating account.
 	if v, ok := d.GetOk("customer_id"); ok {
-		customerId = v.(string)
+		customerID = v.(string)
 	} else {
 		log.Printf("[INFO] No Customer ID provided. Using my_customer.")
-		customerId = "my_customer"
+		customerID = "my_customer"
 	}
 
 	oauthScopes := oauthScopesFromConfigOrDefault(d.Get("oauth_scopes").(*schema.Set))
@@ -92,7 +94,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Credentials:           credentials,
 		ImpersonatedUserEmail: impersonatedUserEmail,
 		OauthScopes:           oauthScopes,
-		CustomerId:            customerId,
+		CustomerId:            customerID,
 	}
 
 	if err := config.loadAndValidate(); err != nil {

--- a/gsuite/resource_group.go
+++ b/gsuite/resource_group.go
@@ -234,6 +234,8 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("admin_created", group.AdminCreated)
 	d.Set("aliases", group.Aliases)
 	d.Set("non_editable_aliases", group.NonEditableAliases)
+	d.Set("description", group.Description)
+	d.Set("name", group.Name)
 
 	return nil
 }

--- a/gsuite/resource_user.go
+++ b/gsuite/resource_user.go
@@ -320,7 +320,7 @@ func resourceUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 	user.SshPublicKeys = userSSHs
 
-	userNamePrefix := "name.0"
+	userNamePrefix := "name"
 	userName := &directory.UserName{
 		FamilyName: d.Get(userNamePrefix + ".family_name").(string),
 		GivenName:  d.Get(userNamePrefix + ".given_name").(string),
@@ -414,7 +414,7 @@ func userPosixCreate(d *schema.ResourceData, userID string, meta interface{}) er
 	}
 	user.PosixAccounts = userPosixs
 
-	userNamePrefix := "name.0"
+	userNamePrefix := "name"
 	userName := &directory.UserName{
 		FamilyName: d.Get(userNamePrefix + ".family_name").(string),
 		GivenName:  d.Get(userNamePrefix + ".given_name").(string),
@@ -606,7 +606,7 @@ func resourceUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		user.CustomSchemas = customSchemas
 	}
 
-	userNamePrefix := "name.0"
+	userNamePrefix := "name"
 	userName := &directory.UserName{
 		FamilyName: d.Get(userNamePrefix + ".family_name").(string),
 		GivenName:  d.Get(userNamePrefix + ".given_name").(string),

--- a/gsuite/resource_user.go
+++ b/gsuite/resource_user.go
@@ -110,7 +110,7 @@ func resourceUser() *schema.Resource {
 			},
 
 			"name": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeMap,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/gsuite/utils.go
+++ b/gsuite/utils.go
@@ -5,8 +5,8 @@ package gsuite
 import (
 	"fmt"
 	"log"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"


### PR DESCRIPTION
Fixes https://github.com/DeviaVir/terraform-provider-gsuite/issues/49

Example:
```
data "gsuite_user" "chase" {
  primary_email = "xxx@xxx"
}

data "gsuite_group" "admin_team" {
  email = "xxx-team@xxx"
}

output "admin-team" {
  value = "${data.gsuite_group.admin_team.member}"
}

output "chase" {
  value = "${data.gsuite_user.chase.name}"
}

```

```
Outputs:

admin-team = [
    {
        email = xxx@xxx,
        etag = "xxx",
        kind = admin#directory#member,
        role = OWNER,
        status = ACTIVE,
        type = USER
    }
]

chase = {
  family_name = xxx
  full_name = Chase xxx
  given_name = Chase
}

```