### PR TITLE
bugfix: already existing member bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOVERSION := 1.12
 PROJECT := github.com/DeviaVir/terraform-provider-gsuite
 OWNER := $(notdir $(patsubst %/,%,$(dir $(PROJECT))))
 NAME := $(notdir $(PROJECT))
-VERSION := 0.1.18-1
+VERSION := 0.1.19
 EXTERNAL_TOOLS = \
 	github.com/golang/dep/cmd/dep
 

--- a/gsuite/resource_group_member.go
+++ b/gsuite/resource_group_member.go
@@ -87,7 +87,7 @@ func resourceGroupMemberCreate(d *schema.ResourceData, meta interface{}) error {
 
 	var createdGroupMember *directory.Member
 	var err error
-	err = retry(func() error {
+	err = retryPassDuplicate(func() error {
 		createdGroupMember, err = config.directory.Members.Insert(group, groupMember).Do()
 		return err
 	})
@@ -136,7 +136,7 @@ func resourceGroupMemberCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Try to read the group member, retrying for 404's
 	err = retryNotFound(func() error {
-		groupMember, err = config.directory.Members.Get(group, createdGroupMember.Id).Do()
+		groupMember, err = config.directory.Members.Get(group, d.Id()).Do()
 		return err
 	})
 


### PR DESCRIPTION
reproduced by removing the terraform resource, creating the group member via the console, and trying to terraform apply: the null pointer is because it tries to use `createdGroupMember`'s id, but it doesn't exist, it is in `locatedGroupMember` instead. However, we are setting `Id` so we can just fetch that instead. I also went ahead and added a retryFunc that skips the duplicate check since that is not needed for the group member insert, it would only eat up minutes of your time.