### PR TITLE
Eventual consistency

### DIFF
--- a/gsuite/resource_user.go
+++ b/gsuite/resource_user.go
@@ -670,6 +670,9 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 	var err error
 	err = retry(func() error {
 		user, err = config.directory.Users.Get(d.Id()).Projection("full").Do()
+		if user != nil && user.Name == nil {
+			return errors.New("Eventual consistency. Please try again")
+		}
 		return err
 	})
 

--- a/gsuite/utils.go
+++ b/gsuite/utils.go
@@ -68,7 +68,7 @@ func retryTime(retryFunc func() error, minutes int, retryNotFound bool, retryPas
 			return resource.RetryableError(err)
 		}
 		if strings.Contains(fmt.Sprintf("%s", err), "Eventual consistency. Please try again") {
-			log.Printf("[DEBUG] Retrying service unavailable from API")
+			log.Printf("[DEBUG] Retrying due to eventual consistency")
 			return resource.RetryableError(err)
 		}
 

--- a/gsuite/utils.go
+++ b/gsuite/utils.go
@@ -67,6 +67,10 @@ func retryTime(retryFunc func() error, minutes int, retryNotFound bool, retryPas
 			log.Printf("[DEBUG] Retrying service unavailable from API")
 			return resource.RetryableError(err)
 		}
+		if strings.Contains(fmt.Sprintf("%s", err), "Eventual consistency. Please try again") {
+			log.Printf("[DEBUG] Retrying service unavailable from API")
+			return resource.RetryableError(err)
+		}
 
 		return resource.NonRetryableError(err)
 	})


### PR DESCRIPTION
@DeviaVir I found this bug:
When GETing a user right after creating it the response may not have the Name field yet. If you retry, it'll eventually be populated and the terraform run will succeed.
This is most likely because adding the user's name is a separate API call that is run after actually creating the user, you can confirm that by running terraform in debug mode where you'll see:
```
PUT /admin/directory/v1/users/XXXXXXX?alt=json&prettyPrint=false HTTP/1.1
Host: www.googleapis.com
User-Agent: google-api-go-client/0.5 (darwin amd64) Terraform/0.12.2
Content-Length: 75
Content-Type: application/json
Accept-Encoding: gzip
 
 {
  "name": {
   "familyName": "Some last name",
   "givenName": "First Name"
  },
  "posixAccounts": []
 }
```

And the Google admin UI also warns you about this eventual consistency:
<img width="438" alt="Screenshot 2019-06-27 at 16 59 10" src="https://user-images.githubusercontent.com/4629568/60281377-c1ac8400-98fc-11e9-90b9-89e13b44360e.png">

I keep running into this problem and this PR  has fixed the reliability of user creation for me.