### PR TITLE
 Add external_ids argument

### DIFF
--- a/examples/user/devteam.tf
+++ b/examples/user/devteam.tf
@@ -36,4 +36,9 @@ resource "gsuite_user" "developer" {
     system_id      = "uid"
     username       = "chase"
   }
+
+  external_ids {
+    type  = "organization"
+    value = "1234"
+  }
 }

--- a/gsuite/resource_user.go
+++ b/gsuite/resource_user.go
@@ -863,7 +863,7 @@ func resourceUserImporter(d *schema.ResourceData, meta interface{}) ([]*schema.R
 	d.Set("name", flattenUserName(id.Name))
 	d.Set("posix_accounts", id.PosixAccounts)
 	d.Set("ssh_public_keys", id.SshPublicKeys)
-  d.Set("external_ids", id.ExternalIds)
+	d.Set("external_ids", id.ExternalIds)
   
 	err, flattenedCustomSchema := flattenCustomSchema(id.CustomSchemas)
 	if err != nil {


### PR DESCRIPTION
With this the externalIds field of a user can be populated.
https://godoc.org/google.golang.org/api/admin/directory/v1#UserExternalId

Example use case: https://gsuiteupdates.googleblog.com/2018/07/employee-id-login-challenge-g-suite.html