### PR TITLE
Add the 'NONE' option to 'who_can_ban_users'

### DIFF
--- a/gsuite/resource_group_settings.go
+++ b/gsuite/resource_group_settings.go
@@ -172,7 +172,7 @@ func resourceGroupSettings() *schema.Resource {
 			"who_can_ban_users": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"OWNERS_ONLY", "OWNERS_AND_MANAGERS", "ALL_MEMBERS", ""}, false),
+				ValidateFunc: validation.StringInSlice([]string{"NONE", "OWNERS_ONLY", "OWNERS_AND_MANAGERS", "ALL_MEMBERS", ""}, false),
 				Default:      "OWNERS_AND_MANAGERS",
 			},
 			"who_can_contact_owner": {


### PR DESCRIPTION
Hey,

The documentation for `whoCanBanUsers` says:
> **Deprecated**. Use the whoCanModerateMembers property instead.

https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups

Now my terraform plan tries to change this all the time.
This is the quick fix that will allow people to continue, though I'm interested to know what your thoughts are on making sure that for the deprecated fields no values are sent unless specified by the user.