### PR TITLE
0.1.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOVERSION := 1.12
 PROJECT := github.com/DeviaVir/terraform-provider-gsuite
 OWNER := $(notdir $(patsubst %/,%,$(dir $(PROJECT))))
 NAME := $(notdir $(PROJECT))
-VERSION := 0.1.24
+VERSION := 0.1.25
 EXTERNAL_TOOLS = \
 	github.com/golang/dep/cmd/dep
 


### PR DESCRIPTION
- Group Settings Import: email attribute needed to prevent crash in subsequent state refresh #91 
- Add the 'NONE' option to 'who_can_ban_users' #89
- Allow configure the recovery email and phone #92