### PR TITLE
Add mention of the group email when an error occurs

### DIFF
--- a/gsuite/data_group_settings.go
+++ b/gsuite/data_group_settings.go
@@ -252,7 +252,7 @@ func dataGroupSettingsRead(d *schema.ResourceData, meta interface{}) error {
 
 	id, err := config.groupSettings.Groups.Get(d.Get("email").(string)).Do()
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error fetching group settings. Make sure the group exists: %s ", err)
+		return fmt.Errorf("[ERROR] Error fetching group settings. Make sure the group '%s' exists: %s ", d.Get("email").(string), err)
 	}
 
 	d.SetId(d.Get("email").(string))

--- a/gsuite/resource_group_settings.go
+++ b/gsuite/resource_group_settings.go
@@ -440,7 +440,7 @@ func resourceGroupSettingsCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}, config.TimeoutMinutes)
 	if err != nil {
-		return fmt.Errorf("[ERROR] Something went wrong while updating group settings: %s", err)
+		return fmt.Errorf("[ERROR] Something went wrong while updating group settings for '%s': %s", d.Get("email").(string), err)
 	}
 
 	return resourceGroupSettingsRead(d, meta)
@@ -722,7 +722,7 @@ func resourceGroupSettingsUpdate(d *schema.ResourceData, meta interface{}) error
 	}, config.TimeoutMinutes)
 
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error updating group settings: %s", err)
+		return fmt.Errorf("[ERROR] Error updating group settings for '%s': %s", d.Get("email").(string), err)
 	}
 
 	return resourceGroupSettingsRead(d, meta)
@@ -784,7 +784,7 @@ func resourceGroupSettingsImporter(d *schema.ResourceData, meta interface{}) ([]
 
 	id, err := config.groupSettings.Groups.Get(d.Id()).Do()
 	if err != nil {
-		return nil, fmt.Errorf("[ERROR] Error fetching group settings. Make sure the group exists: %s ", err)
+		return nil, fmt.Errorf("[ERROR] Error fetching group settings. Make sure the group '%s' exists: %s ", d.Id(), err)
 	}
 
 	d.SetId(d.Id())


### PR DESCRIPTION
Will result in slightly better errors:
> Error: [ERROR] Error updating group settings for 'group@domain.com': googleapi: Error 400: Invalid Value, invalid

Pointing you to the group causing a problem