### PR TITLE
add user aliases resource

### DIFF
--- a/examples/user/devteam.tf
+++ b/examples/user/devteam.tf
@@ -1,4 +1,9 @@
 resource "gsuite_user" "developer" {
+
+  aliases = [
+    "chase@sillevis.net"
+  ]
+
   # advise to set this field to true on creation, then false afterwards
   change_password_next_login = true
 

--- a/gsuite/utils.go
+++ b/gsuite/utils.go
@@ -110,3 +110,20 @@ func convertStringSet(set *schema.Set) []string {
 	}
 	return s
 }
+
+func stringSliceDifference(left []string, right []string) []string {
+	var d []string
+	for _, l := range left {
+		f := false
+		for _, r := range right {
+			if r == l {
+				f = true
+				break
+			}
+		}
+		if !f {
+			d = append(d, l)
+		}
+	}
+	return d
+}


### PR DESCRIPTION
Any interest in bringing in a `gsuite_user_aliases` resource for managing aliases.  I took the route of making it a separate resource instead of nesting multiple api calls within the existing `gsuite_user` resource as the alias updates are independent of the user updates.  