### PR TITLE
remove update from creation

### DIFF
--- a/examples/user/devteam.tf
+++ b/examples/user/devteam.tf
@@ -53,4 +53,7 @@ resource "gsuite_user" "developer" {
     type  = "organization"
     value = "1234"
   }
+
+  # If omitted or `true` existing GSuite users defined as Terraform resources will be imported by `terraform apply`.
+  update_existing = true
 }

--- a/gsuite/config.go
+++ b/gsuite/config.go
@@ -39,6 +39,8 @@ type Config struct {
 
 	OauthScopes []string
 
+	UpdateExisting bool
+
 	directory *directory.Service
 
 	groupSettings *groupSettings.Service

--- a/gsuite/provider.go
+++ b/gsuite/provider.go
@@ -43,6 +43,10 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Default:  1, // 1 + (n*2) roof 16 = 1+2+4+8+16 = 31 seconds, 1 min should be "normal" operations
 			},
+			"update_existing": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"gsuite_group":           dataGroup(),
@@ -111,12 +115,19 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 	timeoutMinutes := d.Get("timeout_minutes").(int)
 
 	oauthScopes := oauthScopesFromConfigOrDefault(d.Get("oauth_scopes").(*schema.Set))
+
+	updateExisting := true
+	if v, ok := d.GetOk("update_existing"); ok {
+		updateExisting = v.(bool)
+	}
+
 	config := Config{
 		Credentials:           credentials,
 		ImpersonatedUserEmail: impersonatedUserEmail,
 		OauthScopes:           oauthScopes,
 		CustomerId:            customerID,
 		TimeoutMinutes:        timeoutMinutes,
+		UpdateExisting:        updateExisting,
 	}
 
 	if err := config.loadAndValidate(terraformVersion); err != nil {


### PR DESCRIPTION
@DeviaVir, fairly straight forward change to prevent the same user getting imported as multiple terraform resources by accident.  This does change the behavior on initial creations (i.e., no longer imports so you'll have to explicitly import existing users).