### PR TITLE
validate that the local portion of the group email doesn't exceed 63 characters

### DIFF
--- a/gsuite/resource_group.go
+++ b/gsuite/resource_group.go
@@ -64,22 +64,6 @@ func resourceGroup() *schema.Resource {
 	}
 }
 
-func validateEmail(v interface{}, k string) (warnings []string, errors []error) {
-	if v == nil || v.(string) == "" {
-		return
-	}
-	email := v.(string)
-	// TODO: This does not account for non-standard but still RFC compliant
-	// email addresses such as "some@email"@domain.com
-	local := strings.Split(email, "@")[0]
-	if len(local) > 63 {
-		errors = append(errors,
-			fmt.Errorf("local portion of email %s exceeds 63 characters", email))
-	}
-
-	return
-}
-
 func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 

--- a/gsuite/resource_group.go
+++ b/gsuite/resource_group.go
@@ -26,6 +26,7 @@ func resourceGroup() *schema.Resource {
 				StateFunc: func(val interface{}) string {
 					return strings.ToLower(val.(string))
 				},
+				ValidateFunc: validateEmail,
 			},
 
 			"aliases": {
@@ -61,6 +62,22 @@ func resourceGroup() *schema.Resource {
 			},
 		},
 	}
+}
+
+func validateEmail(v interface{}, k string) (warnings []string, errors []error) {
+	if v == nil || v.(string) == "" {
+		return
+	}
+	email := v.(string)
+	// TODO: This does not account for non-standard but still RFC compliant
+	// email addresses such as "some@email"@domain.com
+	local := strings.Split(email, "@")[0]
+	if len(local) > 63 {
+		errors = append(errors,
+			fmt.Errorf("local portion of email %s exceeds 63 characters", email))
+	}
+
+	return
 }
 
 func resourceGroupCreate(d *schema.ResourceData, meta interface{}) error {

--- a/gsuite/resource_group_member.go
+++ b/gsuite/resource_group_member.go
@@ -46,6 +46,7 @@ var schemaMember = map[string]*schema.Schema{
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			return strings.ToLower(strings.Trim(old, `"`)) == strings.ToLower(strings.Trim(new, `"`))
 		},
+		ValidateFunc: validateEmail,
 	},
 }
 

--- a/gsuite/resource_group_members.go
+++ b/gsuite/resource_group_members.go
@@ -18,6 +18,7 @@ var schemaGroupMembersEmail = map[string]*schema.Schema{
 		StateFunc: func(val interface{}) string {
 			return strings.ToLower(val.(string))
 		},
+		ValidateFunc: validateEmail,
 	},
 }
 

--- a/gsuite/resource_group_settings.go
+++ b/gsuite/resource_group_settings.go
@@ -39,8 +39,9 @@ func resourceGroupSettings() *schema.Resource {
 				Computed: true,
 			},
 			"email": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateEmail,
 			},
 			"allow_external_members": {
 				Type:     schema.TypeString,

--- a/gsuite/utils.go
+++ b/gsuite/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net/mail"
 	"strings"
 	"time"
 
@@ -126,4 +127,31 @@ func stringSliceDifference(left []string, right []string) []string {
 		}
 	}
 	return d
+}
+
+func validateEmail(v interface{}, k string) (warnings []string, errors []error) {
+	if v == nil || v.(string) == "" {
+		return
+	}
+	email := v.(string)
+
+	e, err := mail.ParseAddress(email)
+	if err != nil {
+		errors = append(errors,
+			fmt.Errorf("unable to parse email address %s", email))
+	}
+
+	if e.Name != "" {
+		errors = append(errors,
+			fmt.Errorf("unexpected email format for %s expected an email format of myemail@domain.com", email))
+	}
+
+	parts := strings.Split(e.Address, "@")
+	local := strings.Join(parts[0:len(parts)-1], "@")
+	if len(local) > 63 {
+		errors = append(errors,
+			fmt.Errorf("local portion of email %s exceeds 63 characters", email))
+	}
+
+	return
 }

--- a/gsuite/utils_test.go
+++ b/gsuite/utils_test.go
@@ -1,0 +1,28 @@
+package gsuite
+
+import (
+	"testing"
+)
+
+func TestValidateEmail(t *testing.T) {
+
+	testCases := []struct {
+		email   string
+		success bool
+	}{
+		{"myemail@domain.com", true},
+		{"Alice <alice@example.com>", false},
+		{"much-much-much-much-much-much-much-much-much-much-much-much-too-long@domain.com", false},
+		{"\"some@much-much-much-much-much-much-much-much-much-much-much-much-too-long\"@domain.com", false},
+	}
+
+	for _, testCase := range testCases {
+		_, errs := validateEmail(testCase.email, "")
+		if len(errs) > 0 && testCase.success {
+			t.Log(errs)
+			t.Errorf("expected a valid email for %s", testCase.email)
+		} else if len(errs) == 0 && !testCase.success {
+			t.Errorf("expected an invalid email for %s", testCase.email)
+		}
+	}
+}


### PR DESCRIPTION
Provisioning gsuite groups with long names returns errors an apply from the API, but it'd be nice to be able to catch the errors a little earlier such as during a terraform plan and provide some more meaningful errors.

Sample resource

```
resource "gsuite_group" "long_group" {
  description = "Testing generation of a group with too long of an email"
  email       = "really-really-really-really-really-really-really-long-name-here@domain.com"
  name        = "groupname"
}
```

I think there is a length restriction to the group name as well but didn't find any info on it with a little searching.  Might be useful to add later.

Error thrown on a tf plan

```
Error: local portion of email really-really-really-really-really-really-really-long-name-here@domain.com exceeds 63 characters

  on main.tf line 2, in resource "gsuite_group" "long_group":
  2: resource "gsuite_group" "long_group" {
```