### PR TITLE
Add gsuite_user_attributes resource

### DIFF
--- a/examples/custom-attributes/custom-attributes.tf
+++ b/examples/custom-attributes/custom-attributes.tf
@@ -1,0 +1,39 @@
+// The below define a custom directory user schema. For additional details on
+// possible types of fields, their values, etc see Google's reference documentation:
+//     https://developers.google.com/admin-sdk/directory/v1/reference/schemas
+resource "gsuite_user_schema" "details" {
+  schema_name  = "additional-details" // Required
+  display_name = "Additional Details" // Optional (default: value of `schema_name`)
+
+  // Defines the schema of a specific field. The `field` element may be
+  // repeated multiple times to define more than a single custom field.
+  field {
+    field_type       = "PHONE"            // Required (valid values: BOOL, DATE, DOUBLE, EMAIL, INT64, PHONE, STRING)
+    field_name       = "internal-phone"   // Required
+    display_name     = "Internal Phone"   // Optional (default: value of `field_name`)
+    indexed          = true               // Optional (default: true)
+    read_access_type = "ALL_DOMAIN_USERS" // Optional (default: ADMINS_AND_SELF)
+    multi_valued     = false              // Optional (default: false)
+  }
+}
+
+data "gsuite_user_attributes" "details" {
+  phone {
+    name  = "internal-phone"
+    value = "555-555-5555"
+  }
+}
+
+resource "gsuite_user" "user" {
+  primary_email = "flast@example.com"
+
+  name {
+    given_name  = "First"
+    family_name = "Last"
+  }
+}
+
+resource "gsuite_user_attributes" "user_attributes" {
+  primary_email = gsuite_user.user.primary_email
+  custom_schema =  data.gsuite_user_attributes.details.json
+}

--- a/gsuite/provider.go
+++ b/gsuite/provider.go
@@ -55,14 +55,14 @@ func Provider() *schema.Provider {
 			"gsuite_user_attributes": dataUserAttributes(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"gsuite_domain":         resourceDomain(),
-			"gsuite_group":          resourceGroup(),
-			"gsuite_group_member":   resourceGroupMember(),
-			"gsuite_group_members":  resourceGroupMembers(),
-			"gsuite_group_settings": resourceGroupSettings(),
-			"gsuite_user":           resourceUser(),
-			"gsuite_user_fields":    resourceUserFields(),
-			"gsuite_user_schema":    resourceUserSchema(),
+			"gsuite_domain":          resourceDomain(),
+			"gsuite_group":           resourceGroup(),
+			"gsuite_group_member":    resourceGroupMember(),
+			"gsuite_group_members":   resourceGroupMembers(),
+			"gsuite_group_settings":  resourceGroupSettings(),
+			"gsuite_user":            resourceUser(),
+			"gsuite_user_attributes": resourceUserAttributes(),
+			"gsuite_user_schema":     resourceUserSchema(),
 		},
 	}
 

--- a/gsuite/provider.go
+++ b/gsuite/provider.go
@@ -61,6 +61,7 @@ func Provider() *schema.Provider {
 			"gsuite_group_members":  resourceGroupMembers(),
 			"gsuite_group_settings": resourceGroupSettings(),
 			"gsuite_user":           resourceUser(),
+			"gsuite_user_fields":    resourceUserFields(),
 			"gsuite_user_schema":    resourceUserSchema(),
 		},
 	}

--- a/gsuite/resource_user_attributes.go
+++ b/gsuite/resource_user_attributes.go
@@ -11,14 +11,14 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-func resourceUserFields() *schema.Resource {
+func resourceUserAttributes() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceUserFieldsCreate,
-		Read:   resourceUserFieldsRead,
-		Update: resourceUserFieldsUpdate,
-		Delete: resourceUserFieldsDelete,
+		Create: resourceUserAttributesCreate,
+		Read:   resourceUserAttributesRead,
+		Update: resourceUserAttributesUpdate,
+		Delete: resourceUserAttributesDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceUserFieldsImporter,
+			State: resourceUserAttributesImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -50,7 +50,7 @@ func resourceUserFields() *schema.Resource {
 	}
 }
 
-func resourceUserFieldsCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceUserAttributesCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	user := &directory.User{}
@@ -82,10 +82,10 @@ func resourceUserFieldsCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(updatedUser.Id)
 	log.Printf("[INFO] Created user fields: %s", updatedUser.PrimaryEmail)
-	return resourceUserFieldsRead(d, meta)
+	return resourceUserAttributesRead(d, meta)
 }
 
-func resourceUserFieldsUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceUserAttributesUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	user := &directory.User{}
@@ -122,10 +122,10 @@ func resourceUserFieldsUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[INFO] Updated user fields: %s", updatedUser.PrimaryEmail)
-	return resourceUserFieldsRead(d, meta)
+	return resourceUserAttributesRead(d, meta)
 }
 
-func resourceUserFieldsRead(d *schema.ResourceData, meta interface{}) error {
+func resourceUserAttributesRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	var user *directory.User
@@ -157,7 +157,7 @@ func resourceUserFieldsRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceUserFieldsDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceUserAttributesDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	user := &directory.User{}
@@ -177,7 +177,7 @@ func resourceUserFieldsDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 // Allow importing using any key (id, email, alias)
-func resourceUserFieldsImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceUserAttributesImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
 
 	id, err := config.directory.Users.Get(d.Id()).Projection("full").Do()

--- a/gsuite/resource_user_fields.go
+++ b/gsuite/resource_user_fields.go
@@ -1,0 +1,199 @@
+package gsuite
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/pkg/errors"
+	directory "google.golang.org/api/admin/directory/v1"
+	"google.golang.org/api/googleapi"
+)
+
+func resourceUserFields() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceUserFieldsCreate,
+		Read:   resourceUserFieldsRead,
+		Update: resourceUserFieldsUpdate,
+		Delete: resourceUserFieldsDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceUserFieldsImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"primary_email": {
+				Type:     schema.TypeString,
+				Required: true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
+			},
+
+			"custom_schema": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceUserFieldsCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	user := &directory.User{}
+
+	if v, ok := d.GetOk("primary_email"); ok {
+		log.Printf("[DEBUG] Setting %s: %s", "primary_email", v.(string))
+		user.PrimaryEmail = strings.ToLower(v.(string))
+	}
+
+	customSchemas := map[string]googleapi.RawMessage{}
+	for i := 0; i < d.Get("custom_schema.#").(int); i++ {
+		entry := d.Get(fmt.Sprintf("custom_schema.%d", i)).(map[string]interface{})
+		customSchemas[entry["name"].(string)] = []byte(entry["value"].(string))
+	}
+	if len(customSchemas) > 0 {
+		user.CustomSchemas = customSchemas
+	}
+
+	var err error
+	var updatedUser *directory.User
+	err = retry(func() error {
+		updatedUser, err = config.directory.Users.Patch(user.PrimaryEmail, user).Do()
+		return err
+	}, config.TimeoutMinutes)
+
+	if err != nil {
+		return fmt.Errorf("[ERROR] Error creating user fields: %s", err)
+	}
+
+	d.SetId(updatedUser.Id)
+	log.Printf("[INFO] Created user fields: %s", updatedUser.PrimaryEmail)
+	return resourceUserFieldsRead(d, meta)
+}
+
+func resourceUserFieldsUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	user := &directory.User{}
+
+	if d.HasChange("primary_email") {
+		if v, ok := d.GetOk("primary_email"); ok {
+			log.Printf("[DEBUG] Updating user primary_email: %s", d.Get("primary_email").(string))
+			user.PrimaryEmail = v.(string)
+		}
+	}
+
+	if d.HasChange("custom_schema") {
+		customSchemas := map[string]googleapi.RawMessage{}
+		for i := 0; i < d.Get("custom_schema.#").(int); i++ {
+			entry := d.Get(fmt.Sprintf("custom_schema.%d", i)).(map[string]interface{})
+			customSchemas[entry["name"].(string)] = []byte(entry["value"].(string))
+		}
+		user.CustomSchemas = customSchemas
+	}
+
+	var updatedUser *directory.User
+	var err error
+	err = retry(func() error {
+		updatedUser, err = config.directory.Users.Update(d.Id(), user).Do()
+		if e, ok := err.(*googleapi.Error); ok {
+			return errors.Wrap(e, e.Body)
+		}
+		return err
+	}, config.TimeoutMinutes)
+
+	if err != nil {
+		log.Printf("[WARN] Please note, a persistent 503 backend error can mean you need to change your posix values to be unique.")
+		return fmt.Errorf("[ERROR] Error updating user fields: %s", err)
+	}
+
+	log.Printf("[INFO] Updated user fields: %s", updatedUser.PrimaryEmail)
+	return resourceUserFieldsRead(d, meta)
+}
+
+func resourceUserFieldsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	var user *directory.User
+	var err error
+	err = retry(func() error {
+		user, err = config.directory.Users.Get(d.Id()).Projection("full").Do()
+		if user != nil && user.Name == nil {
+			return errors.New("Eventual consistency. Please try again")
+		}
+		return err
+	}, config.TimeoutMinutes)
+
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("User %q", d.Id()))
+	}
+
+	d.SetId(user.Id)
+	d.Set("primary_email", user.PrimaryEmail)
+
+	err, flattenedCustomSchema := flattenCustomSchema(user.CustomSchemas)
+	if err != nil {
+		return err
+	}
+
+	if err = d.Set("custom_schema", flattenedCustomSchema); err != nil {
+		return fmt.Errorf("Error setting custom_schema in state: %s", err.Error())
+	}
+
+	return nil
+}
+
+func resourceUserFieldsDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	user := &directory.User{}
+	user.CustomSchemas = map[string]googleapi.RawMessage{}
+
+	var err error
+	err = retry(func() error {
+		_, err = config.directory.Users.Patch(d.Id(), user).Do()
+		return err
+	}, config.TimeoutMinutes)
+	if err != nil {
+		return fmt.Errorf("Error deleting user fields: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// Allow importing using any key (id, email, alias)
+func resourceUserFieldsImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+
+	id, err := config.directory.Users.Get(d.Id()).Projection("full").Do()
+
+	if err != nil {
+		return nil, fmt.Errorf("Error fetching user fields. Make sure the user fields exist: %s ", err)
+	}
+
+	d.SetId(id.Id)
+
+	err, flattenedCustomSchema := flattenCustomSchema(id.CustomSchemas)
+	if err != nil {
+		return []*schema.ResourceData{d}, err
+	}
+
+	d.Set("custom_schema", flattenedCustomSchema)
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
This PR adds the `gsuite_user_attributes` resource, which allows managing a user's custom attributes in custom schemas without having to manage the user itself. Useful when user provisioning is done outside of Terraform.