### PR TITLE
Add reference about scope apps.groups.settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ you will need the following additional scope:
 
     https://www.googleapis.com/auth/admin.directory.userschema
 
+**NOTE 2** If you are creating or modifying group settings
+you will need the following additional scope:
+
+    https://www.googleapis.com/auth/apps.groups.settings
 
 ### Using a service account
 


### PR DESCRIPTION
Hello,

This PR fix the following error when using resource "gsuite_group_settings"

    www-Authenticate: Bearer realm="https://accounts.google.com/", error=insufficient_scope, scope="https://www.googleapis.com/auth/apps.groups.settings"

