### PR TITLE
Updated readme to clarify binary naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installing the Provider
 
     ```sh
     $ mkdir -p $HOME/.terraform.d/plugins
-    $ mv terraform-provider-gsuite $HOME/.terraform.d/plugins/terraform-provider-gsuite
+    $ mv terraform-provider-gsuite_vX.Y.Z $HOME/.terraform.d/plugins/terraform-provider-gsuite_vX.Y.Z
     ```
 
 1. Create your Terraform configurations as normal, and run `terraform init`:


### PR DESCRIPTION
Update to readme to clarify that the provider binary should include the version number, as per the docs [1]. The binaries in the releases do follow this, but the readme may mislead some (eg. me) to believe that the file should be saved without the version, leading to Terraform errors that the required plugin cannot be found.

[1] https://www.terraform.io/docs/configuration/providers.html\#plugin-names-and-versions