### PR TITLE
catch the case where an non-email is provided

### DIFF
--- a/gsuite/utils.go
+++ b/gsuite/utils.go
@@ -187,6 +187,7 @@ func validateEmail(v interface{}, k string) (warnings []string, errors []error) 
 	if err != nil {
 		errors = append(errors,
 			fmt.Errorf("unable to parse email address %s", email))
+		return
 	}
 
 	if e.Name != "" {

--- a/gsuite/utils_test.go
+++ b/gsuite/utils_test.go
@@ -14,6 +14,7 @@ func TestValidateEmail(t *testing.T) {
 		{"Alice <alice@example.com>", false},
 		{"much-much-much-much-much-much-much-much-much-much-much-much-too-long@domain.com", false},
 		{"\"some@much-much-much-much-much-much-much-much-much-much-much-much-too-long\"@domain.com", false},
+		{"not an email address", false},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Ran into a case where a non-email address is supplied to the `validateEmail` function.

```
2020-08-19T00:23:04.610Z [DEBUG] plugin.terraform-provider-gsuite_v0.1.54: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xe0d055]
2020-08-19T00:23:04.610Z [DEBUG] plugin.terraform-provider-gsuite_v0.1.54: 
2020-08-19T00:23:04.610Z [DEBUG] plugin.terraform-provider-gsuite_v0.1.54: goroutine 2535 [running]:
2020-08-19T00:23:04.610Z [DEBUG] plugin.terraform-provider-gsuite_v0.1.54: github.com/DeviaVir/terraform-provider-gsuite/gsuite.validateEmail(0xeb9fa0, 0xc00031f810, 0x1090b3e, 0x5, 0x0, 0x0, 0x4b90dd, 0xf10660, 0xc00031f390, 0x94)
2020-08-19T00:23:04.610Z [DEBUG] plugin.terraform-provider-gsuite_v0.1.54: 	/go/src/github.com/DeviaVir/terraform-provider-gsuite/gsuite/utils.go:192 +0x105
```

This matches a simplified test case:

```
package main
import (
	"fmt"
	"net/mail"
)
func main() {
	e, _ := mail.ParseAddress("not an email address")
	fmt.Println(e.Name)
}
```

```
go run main.go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10c25a2]

goroutine 1 [running]:
main.main()
	/go/src/main.go:10 +0x72
exit status 2
```

* Adding an early `return` if the email parses
* Adding a negative test case