### PR TITLE
Add Note that Group ID is Available Attribute

### DIFF
--- a/website/docs/d/group.md
+++ b/website/docs/d/group.md
@@ -32,6 +32,8 @@ The following arguments are supported:
 
 In addition to the above arguments, the following attributes are exported:
 
+* `id`
+
 * `aliases`
 
 * `name`


### PR DESCRIPTION
While not explicitly doc'ed `id` was available from the data resource for `group`. Explicitly adding it to the docs in case others like myself don't think to try `id` since it wasn't doced. Closes #155 