### PR TITLE
Remove a block which failed with the wrong error

### DIFF
--- a/gsuite/resource_group_members.go
+++ b/gsuite/resource_group_members.go
@@ -198,10 +198,6 @@ func reconcileMembers(d *schema.ResourceData, cfgMembers, apiMembers []map[strin
 					Role: cfgRole,
 				}
 
-				if cfgRole != "MEMBER" {
-					return fmt.Errorf("[ERROR] Error updating groupMember (%s): nested groups should be role MEMBER", cfgMember["email"].(string))
-				}
-
 				var updatedGroupMember *directory.Member
 				var err error
 				err = retryNotFound(func() error {


### PR DESCRIPTION
We had a case where the API had some users with the MEMBER role, but the Terraform config was trying to set the OWNER role to them.

We got `Error: [ERROR] Error updating memberships: [ERROR] Error updating groupMember (x@x.com): nested groups should be role MEMBER` which made no sense.

Is there any reason for that condition to be in the reconcile function?