### PR TITLE
[bugfix] Don't use httpclient unless it is set

### DIFF
--- a/gsuite/config.go
+++ b/gsuite/config.go
@@ -122,12 +122,16 @@ func (c *Config) loadAndValidate(terraformVersion string) error {
 
 	// Use a custom user-agent string. This helps google with analytics and it's
 	// just a nice thing to do.
-	client.Transport = logging.NewTransport("Google", client.Transport)
+	if client != nil {
+		client.Transport = logging.NewTransport("Google", client.Transport)
+		clientOptions = append(clientOptions, option.WithHTTPClient(client))
+
+	}
+
 	userAgent := fmt.Sprintf("(%s %s) Terraform/%s",
 		runtime.GOOS, runtime.GOARCH, terraformVersion)
-
 	context := context.Background()
-	clientOptions = append(clientOptions, option.WithHTTPClient(client))
+
 	// Create the directory service.
 	directorySvc, err := directory.NewService(context, clientOptions...)
 	if err != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -49,11 +49,15 @@ The provider configuration block accepts the following arguments.
 In most cases it is recommended to set them via the indicated environment
 variables in order to keep credential information out of the configuration.
 
-* `credentials` - (Optional) Path to or string content of your credentials. If
-  you have authenticated using `gcloud auth login` and want to test using your
-  personal account you may leave this empty. May be set via the
+* `credentials` - (Optional) Path to or string content of your credentials. This may 
+   also be set via the
   `GOOGLE_CREDENTIALS`, `GOOGLE_CLOUD_KEYFILE_JSON`, `GOOGLE_KEYFILE_JSON`,
-  `GOOGLE_APPLICATION_CREDENTIALS` environment variables.
+  `GOOGLE_APPLICATION_CREDENTIALS` environment variables. If
+  you have authenticated using `gcloud auth login` and want to test using your
+  personal account you may leave this empty. If you are using this provider in a GCP
+  environment, you may leave this empty and the provider will fetch credentials from
+  the [GCP internal metadata server](https://cloud.google.com/compute/docs/storing-retrieving-metadata).
+
 
 * `impersonated_user_email` - (Optional) Service accounts cannot be granted
   access to the Admin API SDK, therefore the service account needs to


### PR DESCRIPTION
Bugfix for changes introduces in https://github.com/DeviaVir/terraform-provider-gsuite/pull/171

- [x] Passes tests
- [x] Binary builds and works as expected
- [x] Documentation added


### Do tests pass?

```
go test -i ./... || exit 1
go test: -i flag is deprecated
echo ./... | \
		xargs -t -n4 go test  -timeout=30s -parallel=4
go test -timeout=30s -parallel=4 ./...
?   	github.com/DeviaVir/terraform-provider-gsuite	[no test files]
ok  	github.com/DeviaVir/terraform-provider-gsuite/gsuite	0.360s
```

### Does binary work as expected?

- [x] atlantis plan runs successfully 
- [x] atlantis apply runs successfully


If metadata endpoint is blocked or email is not configured properly, the following error will show (this is not an error with the code, but a config error):

```
Error: [ERROR] Error creating group: Post "https://admin.googleapis.com/admin/directory/v1/groups?alt=json&prettyPrint=false": impersonate: status code 400: {
  "error": {
    "code": 400,
    "message": "Request contains an invalid argument.",
    "status": "INVALID_ARGUMENT"
  }
}
```