### PR TITLE
Documentation for gsuite_user shouldn't refer to gsuite_user_schema

### DIFF
--- a/website/docs/r/user.md
+++ b/website/docs/r/user.md
@@ -1,12 +1,12 @@
 ---
 layout: "gsuite"
-page_title: "G Suite: gsuite_user_schema"
+page_title: "G Suite: gsuite_user"
 sidebar_current: "docs-gsuite-resource-user-schema"
 description: |-
   Managing a G Suite User Schema.
 ---
 
-# gsuite\_user\_schema
+# gsuite\_user
 
 Provides a resource to create and manage a G Suite User Schema.
 

--- a/website/docs/r/user.md
+++ b/website/docs/r/user.md
@@ -1,14 +1,14 @@
 ---
 layout: "gsuite"
 page_title: "G Suite: gsuite_user"
-sidebar_current: "docs-gsuite-resource-user-schema"
+sidebar_current: "docs-gsuite-resource-user"
 description: |-
-  Managing a G Suite User Schema.
+  Managing a G Suite User.
 ---
 
 # gsuite\_user
 
-Provides a resource to create and manage a G Suite User Schema.
+Provides a resource to create and manage a G Suite User.
 
 **Note** the following behaviors regarding passwords:
 
@@ -88,7 +88,7 @@ The following arguments are supported:
   email addresses.
 
 * `include_in_global_list` - (Optional) Boolean switch to show or hide this user
-  in the global list. 
+  in the global list.
   Valid values are `true` or `false`. Defaults to `true`.
 
 * `is_ip_whitelisted` - (Optional) Boolean switch to enforce whitelisting of the


### PR DESCRIPTION
The [doc page for `gsuite_user`](https://registry.terraform.io/providers/DeviaVir/gsuite/latest/docs/resources/user) (title and description) currently references `gsuite_user_schema`:

![image](https://user-images.githubusercontent.com/1585815/122669310-565fba80-d182-11eb-9143-b251f53b331d.png)

I believe this should instead reference `gsuite_user`.

(I would've expected `sidebar_current: "docs-gsuite-resource-user-schema"` to cause the wrong section to be highlighted; it doesn't, but this PR updates it anyway too.)