### PR TITLE
New Resource: `gsuite_user_alias`

### DIFF
--- a/examples/alias/basic_example.tf
+++ b/examples/alias/basic_example.tf
@@ -12,6 +12,6 @@ resource "gsuite_user" "test" {
 }
 
 resource "gsuite_user_alias" "test" {
-  user_id = gsuite_user.test.id
+  user_id = gsuite_user.test.primary_email
   alias   = "test-alias-replaceWithUuid@domain.ext"
 }

--- a/examples/alias/basic_example.tf
+++ b/examples/alias/basic_example.tf
@@ -1,0 +1,17 @@
+resource "gsuite_user" "test" {
+  name = {
+    family_name = "TestAcc_replaceWithUuid"
+    given_name  = "Test"
+  }
+
+  primary_email = "test_replaceWithUuid@domain.ext"
+
+  lifecycle {
+    ignore = [aliases]
+  }
+}
+
+resource "gsuite_user_alias" "test" {
+  user_id = gsuite_user.test.id
+  alias   = "test-alias-replaceWithUuid@domain.ext"
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	cloud.google.com/go v0.79.0
+	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.13.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1U
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/gsuite/provider.go
+++ b/gsuite/provider.go
@@ -61,6 +61,7 @@ func Provider() *schema.Provider {
 			"gsuite_group_members":   resourceGroupMembers(),
 			"gsuite_group_settings":  resourceGroupSettings(),
 			"gsuite_user":            resourceUser(),
+			"gsuite_user_alias":      resourceUserAlias(),
 			"gsuite_user_attributes": resourceUserAttributes(),
 			"gsuite_user_schema":     resourceUserSchema(),
 		},

--- a/gsuite/resource_user_alias.go
+++ b/gsuite/resource_user_alias.go
@@ -10,10 +10,10 @@ import (
 
 func resourceUserAlias() *schema.Resource {
 	return &schema.Resource{
-		Create:   nil,
-		Read:     nil,
+		Create:   resourceUserAliasCreate,
+		Read:     resourceUserAliasRead,
 		Update:   nil,
-		Delete:   nil,
+		Delete:   resourceUserAliasDelete,
 		Importer: nil,
 		Schema: map[string]*schema.Schema{
 			"user_id": {

--- a/gsuite/resource_user_alias.go
+++ b/gsuite/resource_user_alias.go
@@ -1,0 +1,97 @@
+package gsuite
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	admin "google.golang.org/api/admin/directory/v1"
+)
+
+func resourceUserAlias() *schema.Resource {
+	return &schema.Resource{
+		Create:   nil,
+		Read:     nil,
+		Update:   nil,
+		Delete:   nil,
+		Importer: nil,
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:        schema.TypeString,
+				Description: "ID (userKey) of the user the alias should be applied to.",
+				Required:    true,
+				ForceNew:    true,
+			},
+			"alias": {
+				Type:         schema.TypeString,
+				Description:  "Email alias which should be applied to the user.",
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateEmail,
+			},
+		},
+	}
+}
+
+func resourceUserAliasCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	userId := d.Get("user_id").(string)
+	alias := &admin.Alias{
+		Alias: d.Get("alias").(string),
+	}
+	resp, err := config.directory.Users.Aliases.Insert(userId, alias).Do()
+	if err != nil {
+		return fmt.Errorf("failed to add alias for user (%s): %v", userId, err)
+	}
+	d.SetId(resp.Id)
+	return resourceUserAliasRead(d, meta)
+}
+
+func resourceUserAliasRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	aliasId := d.Get("id").(string)
+	userId := d.Get("user_id").(string)
+	expectedAlias := d.Get("alias").(string)
+
+	resp, err := config.directory.Users.Aliases.List(userId).Do()
+	if err != nil {
+		return fmt.Errorf("could not retrieve aliases for user (%s): %v", userId, err)
+	}
+
+	for _, alias := range resp.Aliases {
+		alias, ok := alias.(admin.Alias)
+		if ok {
+			if aliasId == alias.Id && expectedAlias == alias.Alias {
+				d.SetId(alias.Id)
+				return nil
+			}
+			if expectedAlias == alias.Alias {
+				log.Println(fmt.Sprintf("[WARN] ID (%s) for alias (%s) did not match configuration (%s), could indicate issue with setting the alias in terraform.", alias.Id, alias.Alias, aliasId))
+				d.SetId(alias.Id)
+				return nil
+			}
+		}
+		log.Println(fmt.Sprintf("[ERROR] alias format in response did not match sdk struct, this indicates a probelm with provider or sdk handling: %v", alias))
+	}
+
+	log.Println(fmt.Sprintf("[WARN] no matching alias (%s) found for user (%s).", expectedAlias, userId))
+	d.SetId("")
+	return nil
+}
+
+func resourceUserAliasDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	userId := d.Get("user_id").(string)
+	alias := d.Get("alias").(string)
+
+	err := config.directory.Users.Aliases.Delete(userId, alias).Do()
+	if err != nil {
+		return fmt.Errorf("unable to remove alias (%s) from user (%s): %v", alias, userId, err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/gsuite/resource_user_alias.go
+++ b/gsuite/resource_user_alias.go
@@ -44,14 +44,13 @@ func resourceUserAliasCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to add alias for user (%s): %v", userId, err)
 	}
-	d.SetId(resp.Id)
+	d.SetId(resp.Alias)
 	return resourceUserAliasRead(d, meta)
 }
 
 func resourceUserAliasRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	aliasId := d.Get("id").(string)
 	userId := d.Get("user_id").(string)
 	expectedAlias := d.Get("alias").(string)
 
@@ -63,12 +62,7 @@ func resourceUserAliasRead(d *schema.ResourceData, meta interface{}) error {
 	for _, alias := range resp.Aliases {
 		alias, ok := alias.(admin.Alias)
 		if ok {
-			if aliasId == alias.Id && expectedAlias == alias.Alias {
-				d.SetId(alias.Id)
-				return nil
-			}
 			if expectedAlias == alias.Alias {
-				log.Println(fmt.Sprintf("[WARN] ID (%s) for alias (%s) did not match configuration (%s), could indicate issue with setting the alias in terraform.", alias.Id, alias.Alias, aliasId))
 				d.SetId(alias.Id)
 				return nil
 			}

--- a/gsuite/resource_user_alias.go
+++ b/gsuite/resource_user_alias.go
@@ -51,7 +51,7 @@ func resourceUserAliasCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	bOff := backoff.NewExponentialBackOff()
-	bOff.MaxElapsedTime = time.Minute * 3
+	bOff.MaxElapsedTime = time.Duration(config.TimeoutMinutes) * time.Minute
 	bOff.InitialInterval = time.Second
 
 	err = backoff.Retry(func() error {


### PR DESCRIPTION
This creates a standalone resource for user alias management. Primarily used for situations like ours where we want to set an `alias` on a gsuite account but do not want to have the whole thing managed by Terraform.


There's not much in the way of acceptance tests and such setup in this repo, let me know how you want this "certified", I'm able to provide apply evidence from a locally built provider.